### PR TITLE
Add author for Night and Day entry

### DIFF
--- a/ListOfNovels.txt
+++ b/ListOfNovels.txt
@@ -7,7 +7,7 @@ Daisy Miller,Henry James,DaisyMiller
 Emma,Jane Austen,Emma
 A Handful Of Dust,Evelyn Waugh,HandfulOfDust
 Howards End,E. M. Forster,HowardsEnd
-Night And Day,NightAndDay
+Night And Day,Virginia Woolf,NightAndDay
 Northanger Abbey,Jane Austen,NorthangerAbbey
 Persuasion,Jane Austen,Persuasion
 Pride And Prejudice,Jane Austen,PrideAndPrejudice


### PR DESCRIPTION
Parsing the CSV file without using pandas causes some errors because there's a missing comma (or author) for the NightAndDay entry. This PR adds the corresponding information so that it works properly.